### PR TITLE
feat: Implement lesson notes and edit functionality

### DIFF
--- a/lib/data/app_database.dart
+++ b/lib/data/app_database.dart
@@ -28,7 +28,7 @@ class AppDatabase {
 
     return await openDatabase(
       path,
-      version: 4,
+      version: 5,
       onCreate: _onCreate,
       onUpgrade: _onUpgrade,
     );
@@ -57,6 +57,7 @@ class AppDatabase {
         start_time INTEGER,
         end_time INTEGER,
         is_paid INTEGER,
+        notes TEXT,
         FOREIGN KEY (student_id) REFERENCES students(id) ON DELETE CASCADE
       )
     ''');
@@ -112,6 +113,9 @@ class AppDatabase {
         });
       }
       await db.execute('DROP TABLE lessons_old');
+    }
+    if (oldVersion < 5) {
+      await db.execute('ALTER TABLE lessons ADD COLUMN notes TEXT');
     }
   }
 

--- a/lib/models/lesson.dart
+++ b/lib/models/lesson.dart
@@ -4,6 +4,7 @@ class Lesson {
   final DateTime startTime;
   final DateTime endTime;
   final bool isPaid;
+  final String? notes;
 
   Lesson({
     this.id,
@@ -11,6 +12,7 @@ class Lesson {
     required this.startTime,
     required this.endTime,
     this.isPaid = false,
+    this.notes,
   });
 
   Map<String, dynamic> toMap() {
@@ -20,6 +22,7 @@ class Lesson {
       'start_time': startTime.millisecondsSinceEpoch,
       'end_time': endTime.millisecondsSinceEpoch,
       'is_paid': isPaid ? 1 : 0,
+      'notes': notes,
     };
   }
 
@@ -30,6 +33,7 @@ class Lesson {
       startTime: DateTime.fromMillisecondsSinceEpoch(map['start_time'] as int),
       endTime: DateTime.fromMillisecondsSinceEpoch(map['end_time'] as int),
       isPaid: (map['is_paid'] as int) == 1,
+      notes: map['notes'] as String?,
     );
   }
 }

--- a/lib/screens/add_lesson_screen.dart
+++ b/lib/screens/add_lesson_screen.dart
@@ -27,6 +27,7 @@ class _AddLessonScreenState extends State<AddLessonScreen> {
   late DateTime _lessonDate;
   TimeOfDay? _startTime;
   TimeOfDay? _endTime;
+  late TextEditingController _notesController;
   bool _isFormValid = false;
 
   bool _duplicateLessons = false;
@@ -37,12 +38,14 @@ class _AddLessonScreenState extends State<AddLessonScreen> {
   void initState() {
     super.initState();
     _lessonDate = widget.selectedDate;
+    _notesController = TextEditingController();
 
     if (widget.lessonToEdit != null) {
       final lesson = widget.lessonToEdit!;
       _lessonDate = lesson.startTime;
       _startTime = TimeOfDay.fromDateTime(lesson.startTime);
       _endTime = TimeOfDay.fromDateTime(lesson.endTime);
+      _notesController.text = lesson.notes ?? '';
       try {
         _selectedStudent = widget.students.firstWhere(
           (s) => s.id == lesson.studentId,
@@ -110,6 +113,7 @@ class _AddLessonScreenState extends State<AddLessonScreen> {
         startTime: lessonStartTime,
         endTime: lessonEndTime,
         isPaid: widget.lessonToEdit!.isPaid,
+        notes: _notesController.text,
       );
       await database.updateLesson(lessonToUpdate);
     } else if (_duplicateLessons &&
@@ -137,6 +141,7 @@ class _AddLessonScreenState extends State<AddLessonScreen> {
                 _endTime!.hour,
                 _endTime!.minute,
               ),
+              notes: _notesController.text,
             ),
           );
         }
@@ -152,6 +157,7 @@ class _AddLessonScreenState extends State<AddLessonScreen> {
           studentId: student.id!,
           startTime: lessonStartTime,
           endTime: lessonEndTime,
+          notes: _notesController.text,
         ),
       );
       await database.insertLessons(lessonsToSave);
@@ -268,6 +274,25 @@ class _AddLessonScreenState extends State<AddLessonScreen> {
                   isExpanded: true,
                   validator: (value) =>
                       value == null ? 'Пожалуйста, выберите ученика' : null,
+                ),
+              ),
+            ),
+            _buildSectionTitle('Примечания'),
+            Card(
+              color: Colors.white,
+              margin: const EdgeInsets.symmetric(vertical: 4.0),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(15.0),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: TextFormField(
+                  controller: _notesController,
+                  decoration: const InputDecoration(
+                    hintText: 'Добавьте примечание к занятию...',
+                    border: InputBorder.none,
+                  ),
+                  maxLines: 3,
                 ),
               ),
             ),

--- a/lib/screens/schedule_screen.dart
+++ b/lib/screens/schedule_screen.dart
@@ -208,13 +208,28 @@ class _ScheduleScreenState extends State<ScheduleScreen>
     final startTime = DateFormat('HH:mm').format(lesson.startTime);
     final endTime = DateFormat('HH:mm').format(lesson.endTime);
     final studentName = '${student.name} ${student.surname ?? ''}';
+    final hasNotes = lesson.notes != null && lesson.notes!.isNotEmpty;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
       child: ListTile(
         title: Text('$startTime - $endTime'),
-        subtitle: Text(studentName),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(studentName),
+            if (hasNotes) ...[
+              const SizedBox(height: 4),
+              Text(
+                lesson.notes!,
+                style: TextStyle(color: Colors.grey[600]),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ],
+        ),
         trailing: IconButton(
           icon: const Icon(Icons.more_vert),
           onPressed: () => _showLessonMenu(context, lesson, student),
@@ -253,6 +268,25 @@ class _ScheduleScreenState extends State<ScheduleScreen>
                 title: const Text('Занятие оплачено'),
                 onTap: () {
                   Navigator.of(context).pop();
+                },
+              ),
+              ListTile(
+                title: const Text('Редактировать'),
+                onTap: () async {
+                  Navigator.of(context).pop();
+                  final result = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => AddLessonScreen(
+                        students: _students,
+                        selectedDate: lesson.startTime,
+                        lessonToEdit: lesson,
+                      ),
+                    ),
+                  );
+                  if (result == true) {
+                    await _loadAllData();
+                  }
                 },
               ),
               ListTile(
@@ -604,30 +638,7 @@ class _ScheduleScreenState extends State<ScheduleScreen>
                   itemBuilder: (context, index) {
                     final lesson = _lessons[index]['lesson'] as Lesson;
                     final student = _lessons[index]['student'] as Student;
-                    return ListTile(
-                      title: Text('Занятие с ${student.name}'),
-                      subtitle: Text('Цена: ${student.price} руб.'),
-                      trailing: lesson.isPaid
-                          ? const Icon(Icons.check_circle, color: Colors.green)
-                          : const Icon(Icons.warning, color: Colors.orange),
-                      onTap: () async {
-                        final result = await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => AddLessonScreen(
-                              students: _students,
-                              selectedDate: lesson.startTime,
-                              lessonToEdit: lesson,
-                            ),
-                          ),
-                        );
-                        if (result == true) {
-                          await _loadAllData();
-                        }
-                      },
-                      onLongPress: () =>
-                          _showCancelOptionsDialog(lesson, student),
-                    );
+                    return _buildLessonCard(lesson, student);
                   },
                 ),
         ),


### PR DESCRIPTION
This commit introduces several features and improvements:

- Unifies the lesson card style across the 'List' and 'Calendar' tabs for a consistent UI.
- Adds a 'notes' field to lessons, allowing users to add and view notes for each session.
- Implements the ability to edit existing lessons via a new 'Edit' option in the lesson menu.