### PR TITLE
feat(finance): Add ability to toggle lesson payment status

### DIFF
--- a/lib/screens/finance_screen.dart
+++ b/lib/screens/finance_screen.dart
@@ -41,10 +41,6 @@ class _FinanceScreenState extends State<FinanceScreen> {
       }
     }
 
-    data.sort(
-      (a, b) => (b['start_time'] as int).compareTo(a['start_time'] as int),
-    );
-
     if (!mounted) return;
     setState(() {
       _financialData = data;
@@ -52,6 +48,11 @@ class _FinanceScreenState extends State<FinanceScreen> {
       _unpaidAmount = unpaid;
       _isLoading = false;
     });
+  }
+
+  Future<void> _toggleLessonPaidStatus(int lessonId, bool isPaid) async {
+    await _database.updateLessonIsPaid(lessonId, !isPaid);
+    await _loadFinancialData();
   }
 
   @override
@@ -141,6 +142,10 @@ class _FinanceScreenState extends State<FinanceScreen> {
 
         return Card(
           child: ListTile(
+            onTap: () => _toggleLessonPaidStatus(
+              lesson['id'] as int,
+              isPaid,
+            ),
             leading: Icon(
               isPaid ? Icons.check_circle : Icons.cancel,
               color: isPaid ? Colors.green : Colors.red,


### PR DESCRIPTION
Refactored the Finance screen to allow users to change the payment status of a lesson.

- Added an `onTap` handler to each lesson in the finance list.
- Tapping a lesson now toggles its `is_paid` status in the database.
- The UI, including the summary and the lesson list, refreshes automatically to reflect the change.
- Removed a redundant client-side sort in the `_loadFinancialData` method, as the data is already sorted by the database query.