### PR TITLE
feat(finances): Enhance income statistics UI

### DIFF
--- a/lib/screens/finance_screen.dart
+++ b/lib/screens/finance_screen.dart
@@ -49,8 +49,14 @@ class _FinanceScreenState extends State<FinanceScreen>
             child: TabBar(
               controller: _tabController,
               tabs: const [
-                Tab(text: 'Занятия'),
-                Tab(text: 'Статистика доходов'),
+                Tab(
+                  icon: Icon(Icons.payment),
+                  text: 'Занятия',
+                ),
+                Tab(
+                  icon: Icon(Icons.bar_chart),
+                  text: 'Статистика',
+                ),
               ],
               labelColor: Colors.white,
               unselectedLabelColor: Colors.white70,


### PR DESCRIPTION
This commit introduces several improvements to the income statistics tab on the finance screen.

- Adds icons to the 'Занятия' and 'Статистика' tabs for better visual identification.
- Renames the 'Статистика доходов' tab to 'Статистика' for brevity.
- Updates the income chart to display the earned amount vertically inside each bar.
- Ensures that months with no income are represented by a grey bar.
- Adjusts the chart's container to prevent it from expanding to the full page height, making the layout cleaner.
- Styles the dropdown menu items for the date filter to include icons and rounded corners, matching the overall UI aesthetic.